### PR TITLE
docs: wrong quantity and type of input args in documentation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -84,7 +84,7 @@ def return_hexadecimal(a: int) -> float:
     a: int
 
     Returns:
-    float
+    str
     '''
 
     return hex(a)

--- a/src/utils.py
+++ b/src/utils.py
@@ -81,7 +81,7 @@ def return_hexadecimal(a: int) -> float:
     ...
 
     Args:
-    a: int
+a: float
 
     Returns:
     str

--- a/src/utils.py
+++ b/src/utils.py
@@ -81,8 +81,7 @@ def return_hexadecimal(a: int) -> float:
     ...
 
     Args:
-    a: float
-    b: float
+    a: int
 
     Returns:
     float


### PR DESCRIPTION
# Description

Changed n of args of hexadecimal conversion function (to 1) + changed args type from float to int

- resolves #6 

# Type of change

- **docs**: Documentation only changes


